### PR TITLE
chore: increase base timeouts

### DIFF
--- a/test/spec/base/base.js
+++ b/test/spec/base/base.js
@@ -12,5 +12,5 @@ function validateDiagram(results, done) {
   }
 }
 
-
-describeSuite('base', __dirname + '/diagrams', validateDiagram, { timeout: 4000 });
+// creating subprocess planes for complex diagram takes a while
+describeSuite('base', __dirname + '/diagrams', validateDiagram, { timeout: 25000 });


### PR DESCRIPTION
Increases timeout for diagram imports. With 9.0.0, out import logic got more complicated and the complex diagram test cases comes with some collapsed subprocesses, so we need to create new planes for those

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
