### PR TITLE
fix: correctly name png renderings in miwg suite

### DIFF
--- a/test/postprocess/miwg-rename.js
+++ b/test/postprocess/miwg-rename.js
@@ -73,7 +73,7 @@ function importRename(str) {
     if (multi) {
       return '.' + diagramIndex + '-import.' + ext;
     } else {
-      return '-import' + ext;
+      return '-import.' + ext;
     };
   });
 }


### PR DESCRIPTION
When I run the BPMN MIWG suite, the png files were named like `A.1.0-importpng`. This adds missing dot before the extension.