### PR TITLE
Update MIWG part

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,9 +23,9 @@ module.exports = function(grunt) {
           'test/spec/miwg/*.js'
         ]
       },
-      miwg_rename: {
+      miwg_postprocess: {
         src: [
-          'test/postprocess/miwg-rename.js'
+          'test/postprocess/miwg-postprocess.js'
         ]
       },
       image_diff: {
@@ -104,7 +104,7 @@ module.exports = function(grunt) {
       return grunt.task.run([ 'mochaTest:image_diff' ]);
     }
 
-    return grunt.task.run([ 'mochaTest:test', 'mochaTest:miwg_rename' ]);
+    return grunt.task.run([ 'mochaTest:test', 'mochaTest:miwg_postprocess' ]);
   });
 
   grunt.registerTask('bundle', [ 'browserify:modeler', 'uglify:modeler' ]);

--- a/test/integration/skeleton/import.html
+++ b/test/integration/skeleton/import.html
@@ -44,6 +44,11 @@
 
         var diagrams = renderer.getDefinitions().diagrams;
 
+        // remove empty diagrams
+        diagrams = diagrams.filter(function(diagram) {
+          return diagram.plane.get('planeElement').length;
+        });
+
         return snapshotAndOpenNext(renderer, diagrams[0], diagrams, function(err) {
           if (err) {
             console.log('snapshot initial reached FAIL\n' + err);

--- a/test/postprocess/miwg-postprocess.js
+++ b/test/postprocess/miwg-postprocess.js
@@ -6,7 +6,18 @@ var glob = require('glob'),
 var BASE = 'tmp/integration/bpmn-miwg-test-suite';
 
 
-describe('miwg rename', function() {
+describe('miwg postprocess', function() {
+
+  it('should remove excessive roundtrip files', function() {
+
+    var roundtripFiles = glob.sync('*.bpmn', { cwd: BASE });
+
+    roundtripFiles.forEach(function(f) {
+      if (/-\d+-imported-[2-9]\.bpmn$/g.test(f)) {
+        fs.unlinkSync(path.join(BASE, f));
+      }
+    });
+  })
 
   it('should organize miwg test results according to import/export/roundtrip file pattern', function() {
 
@@ -55,15 +66,10 @@ describe('miwg rename', function() {
 
 });
 
-
 function roundtripRename(str) {
 
   return str.replace(/-(\d)+-imported(-(\d)+)?\.bpmn/g, function(match, run, multi, diagramIndex) {
-    if (multi) {
-      return '.' + diagramIndex + '-roundtrip.bpmn';
-    } else {
-      return '-roundtrip.bpmn'
-    };
+    return '-roundtrip.bpmn'
   });
 }
 
@@ -71,7 +77,7 @@ function importRename(str) {
 
   return str.replace(/-(\d)+-imported(-(\d)+)?\.(svg|png)/g, function(match, run, multi, diagramIndex, ext) {
     if (multi) {
-      return '.' + diagramIndex + '-import.' + ext;
+      return '-import.' + diagramIndex + '.' + ext;
     } else {
       return '-import.' + ext;
     };


### PR DESCRIPTION
This PR:

* removes empty diagrams created automatically for collapsed subprocesses from the BPMN MIWG renders
* makes sure only one roundtrip file is created, and that file names follow the bpmn-miwg-test-suite rules