### PR TITLE
fix: wait for results of snapshots for import

### DIFF
--- a/lib/snapshot/commands/snapshot.js
+++ b/lib/snapshot/commands/snapshot.js
@@ -12,7 +12,7 @@ function SnapshotCommand(params, bpmnjs) {
 
       console.log('snapshot ' + name + ' reached SUCCESS');
 
-      bpmnjs.saveSVG().then(function(result){
+      var saveSVG = bpmnjs.saveSVG().then(function(result) {
 
         console.log('snapshot ' + name + ' svg SUCCESS ' + '\n' + result.svg);
 
@@ -20,16 +20,25 @@ function SnapshotCommand(params, bpmnjs) {
 
         console.log('snapshot ' + name + ' svg FAIL\n');
         console.log(err.message);
+
+        throw err;
       });
 
-      bpmnjs.saveXML({ format: true }).then(function(result) {
+      var saveXML = bpmnjs.saveXML({ format: true }).then(function(result) {
 
         console.log('snapshot ' + name + ' bpmn SUCCESS\n' + result.xml);
       }).catch(function(err) {
 
         console.log('snapshot ' + name + ' bpmn FAIL\n');
         console.log(err.message);
+
+        throw err;
       });
+
+      return Promise.all([
+        saveSVG,
+        saveXML
+      ]);
     }
   };
 }

--- a/test/integration/skeleton/import.html
+++ b/test/integration/skeleton/import.html
@@ -49,13 +49,9 @@
           return diagram.plane.get('planeElement').length;
         });
 
-        return snapshotAndOpenNext(renderer, diagrams[0], diagrams, function(err) {
-          if (err) {
-            console.log('snapshot initial reached FAIL\n' + err);
-          }
-
-          console.log('done');
-        });
+        return snapshotAndOpenNext(renderer, diagrams[0], diagrams);
+      }).then(function() {
+        console.log('done');
       }).catch(function(err) {
 
         console.log('snapshot initial reached FAIL\n' + err);
@@ -63,7 +59,7 @@
       });
 
 
-      function snapshotAndOpenNext(renderer, currentDiagram, diagrams, done) {
+      function snapshotAndOpenNext(renderer, currentDiagram, diagrams) {
 
         var cli  = renderer.get('cli'),
             canvas = renderer.get('canvas');
@@ -72,29 +68,19 @@
 
         var index = diagrams.indexOf(currentDiagram);
 
-        // TODO(nikku): this is/could be asynchronous;
-        // we must properly await its completion
-        cli.snapshot('imported' + (diagrams.length > 1 ? '-' + (index + 1) : ''));
+        return cli.snapshot('imported' + (diagrams.length > 1 ? '-' + (index + 1) : ''))
+          .then(function() {
+            var next = diagrams[index + 1];
 
-        var next = diagrams[index + 1];
-
-        if (!next) {
-          return done();
-        }
-
-        return setTimeout(function() {
-
-          return renderer.open(next, function(err) {
-
-            if (err) {
-              return done(err);
+            if (!next) {
+              return;
             }
 
-            return snapshotAndOpenNext(renderer, next, diagrams, done);
+            return renderer.open(next).then(function() {
+              return snapshotAndOpenNext(renderer, diagrams[index + 1], diagrams)
+            })
           });
-        }, 500);
       }
-
     }
 
     setTimeout(test, 250);


### PR DESCRIPTION
This fixes the problem for BPMN MIWG tests. However, there are also [other snapshot usages](https://github.com/bpmn-io/bpmn-js-integration/search?q=snapshot) which require to be fixed separately. I believe we could do it together with ditching PhantomJS, so that we switch to async/await.

Closes #26
