### PR TITLE
Automatically generate BPMN MIWG submission

### DIFF
--- a/.github/workflows/MIWG.yml
+++ b/.github/workflows/MIWG.yml
@@ -1,0 +1,36 @@
+name: CI
+on: workflow_dispatch
+jobs:
+  "Create MIWG submission":
+
+    env:
+      MIWG_PATH: tmp/bpmn-miwg-test-suite
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        node-version: [ 14 ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Checkout MIWG Test Suite
+      run: |
+        mkdir -p ${{ env.MIWG_PATH }}
+        git clone https://github.com/bpmn-io/bpmn-miwg-test-suite.git ${{ env.MIWG_PATH }}
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: npm ci
+    - name: Create submission files
+      run: npm run test:miwg
+    - name: Prepare pull request
+      env:
+        BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
+        BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
+        BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
+      run: ./tasks/prepare-submission.sh

--- a/tasks/prepare-submission.sh
+++ b/tasks/prepare-submission.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+TOOLKIT_VERSION="$(node -p "require('bpmn-js/package.json').version")"
+BRANCH_NAME="submit-$TOOLKIT_VERSION"
+FORK_REPO="https://$BPMN_IO_TOKEN@github.com/bpmn-io/bpmn-miwg-test-suite.git"
+
+git -C $MIWG_PATH switch -c $BRANCH_NAME
+
+SUBMISSION_PATH="$(node -p "require('./test/spec/miwg-helper').submissionPath()")"
+
+cp -R tmp/integration/bpmn-miwg-test-suite/ "$SUBMISSION_PATH"
+
+rm -f "$SUBMISSION_PATH"/*.html
+rm -f "$SUBMISSION_PATH"/*.json
+rm -f "$SUBMISSION_PATH"/*.svg
+
+mv "$SUBMISSION_PATH" "$MIWG_PATH/bpmn.io (Camunda Modeler) $TOOLKIT_VERSION"
+
+node $(dirname $0)/update-tools-list.js
+
+git config user.email "$BPMN_IO_EMAIL"
+git config user.name "$BPMN_IO_USERNAME"
+git config push.default simple
+
+git -C $MIWG_PATH add -A
+git -C $MIWG_PATH commit -m "feat: prepare bpmn.io $TOOLKIT_VERSION submission"
+
+git -C $MIWG_PATH push "$FORK_REPO" "$BRANCH_NAME"
+
+echo "Open PR with https://github.com/bpmn-miwg/bpmn-miwg-test-suite/compare/master...bpmn-io:bpmn-miwg-test-suite:$BRANCH_NAME"

--- a/tasks/update-tools-list.js
+++ b/tasks/update-tools-list.js
@@ -1,0 +1,25 @@
+const { readFileSync: read, writeFileSync: write } = require('fs');
+
+const { resourcePath } = require('../test/spec/miwg-helper');
+
+const toolsListLocation = resourcePath('tools-tested-by-miwg.json');
+
+const toolsList = JSON.parse(read(toolsListLocation, 'utf-8'));
+
+const entry = toolsList.tools.find(entry => entry.tool === 'bpmn.io (Camunda Modeler)');
+
+entry.version = process.env.TOOLKIT_VERSION;
+
+const currentYear = `${new Date().getFullYear()}`;
+
+entry.lastResultsSubmitted = currentYear;
+
+const demosList = entry.participatedInDemosByYear.split(',');
+
+if (!demosList.includes(currentYear)) {
+  demosList.unshift(currentYear);
+}
+
+entry.participatedInDemosByYear = demosList.join(',');
+
+write(toolsListLocation, JSON.stringify(toolsList, null, 2), 'utf-8');


### PR DESCRIPTION
This adds a manually triggered action (will be available at https://github.com/bpmn-io/bpmn-js-integration/actions/workflows/MIWG.yml) which prepares the submission. What needs to be done by a human is to draw the `export` model for newly added Reference diagrams, to check whether renders are OK, and to create the PR.
