### PR TITLE
fix: use path.resolve instead fs.realPathSync

### DIFF
--- a/test/spec/helper.js
+++ b/test/spec/helper.js
@@ -18,7 +18,7 @@ var BPMN_XSD = require.resolve('bpmn-moddle/resources/bpmn/xsd/BPMN20.xsd');
 
 var browser = require('../integration/browser');
 
-var bpmnJsDistPath = fs.realpathSync('dist/bpmn.js');
+var bpmnJsDistPath = path.resolve(__dirname, '../../dist/bpmn.js');
 
 
 function escapeString(str) {


### PR DESCRIPTION
The `fs.realPathSync` usage assumes that the script is executed from the root of the package. This breaks the automated flow because the cwd is in `tasks`. 