### PR TITLE
fix: copy files instead of directory

### DIFF
--- a/tasks/prepare-submission.sh
+++ b/tasks/prepare-submission.sh
@@ -10,7 +10,7 @@ git -C $MIWG_PATH switch -c $BRANCH_NAME
 
 SUBMISSION_PATH="$(node -p "require('./test/spec/miwg-helper').submissionPath()")"
 
-cp -R tmp/integration/bpmn-miwg-test-suite/ "$SUBMISSION_PATH"
+cp tmp/integration/bpmn-miwg-test-suite/* "$SUBMISSION_PATH"
 
 rm -f "$SUBMISSION_PATH"/*.html
 rm -f "$SUBMISSION_PATH"/*.json


### PR DESCRIPTION
I noticed that the copy command copied the whole directory instead of its contents: https://github.com/bpmn-io/bpmn-miwg-test-suite/tree/submit-10.2.0/bpmn.io%20(Camunda%20Modeler)%2010.2.0

This is to fix the problem.